### PR TITLE
Install iputils-ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN \
   apt-get update && \
   apt-get install -y cmake apt-utils build-essential && \
   apt-get install -y libboost-dev libboost-thread-dev libboost-system-dev libsqlite3-dev subversion curl libcurl4-openssl-dev libusb-dev zlib1g-dev && \
+  apt-get install -y iputils-ping && \
   apt-get clean && \
   apt-get autoclean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Is it possible to add iputils-ping in the Dockerfile?
It is useful to be able to ping a device with a LUA script for example.
Thanks